### PR TITLE
Fallback configuration

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -64,6 +64,23 @@ const curvegridTestnet = {
   },
 } as const satisfies Chain;
 
+/*
+  CUSTOM CHAIN TEMPLATE:
+  If you need to add support for a chain not in the chainList above,
+  uncomment and modify this template:
+
+const customChain = {
+  id: YOUR_CHAIN_ID,
+  name: 'Your Chain Name',
+  nativeCurrency: { name: 'Token Name', symbol: 'SYMBOL', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://your-rpc-url-here'] },
+  },
+} as const satisfies Chain;
+
+Then add customChain to the chainList array below.
+*/
+
 // Combine wagmi chains with custom configurations
 const chainList = [
    arbitrum, arbitrumSepolia,
@@ -107,3 +124,4 @@ export function Providers({ children }: { children: React.ReactNode }) {
     </WagmiProvider>
   );
 }
+

--- a/postinstall.js
+++ b/postinstall.js
@@ -423,7 +423,13 @@ async function writeConfiguration(config) {
     blockchainConfig = blockchainConfig.replace(/web3Key:.*/, `web3Key:\n    '${config.web3Key}',`);
   } else {
     blockchainConfig = blockchainConfig.replace(/web3Key:.*/, `// web3Key:`);
-    blockchainConfig = blockchainConfig.replace(/rpcUrl:.*/, `rpcUrl: '${CHAIN_ID_TO_RPC[config.chainID].url}',`);
+    const chainInfo = CHAIN_ID_TO_RPC[config.chainID];
+    if (!chainInfo) {
+      console.warn(`⚠️  Warning: Chain ID ${config.chainID} not found in supported RPC list. You need to manually configure the RPC URL in blockchain/deployment-config.development.js`);
+      blockchainConfig = blockchainConfig.replace(/rpcUrl:.*/, `rpcUrl: 'YOUR_RPC_URL_HERE', // Chain ID ${config.chainID} does not support automatic configuration`);
+    } else {
+      blockchainConfig = blockchainConfig.replace(/rpcUrl:.*/, `rpcUrl: '${chainInfo.url}',`);
+    }
   }
   blockchainConfig = blockchainConfig.replace(/deployerPrivateKey:.*/, `deployerPrivateKey: '${config.wallet.privateKey}',`);
   fs.writeFileSync(blockchainConfigPath, blockchainConfig, 'utf8');

--- a/postinstall.js
+++ b/postinstall.js
@@ -447,6 +447,14 @@ async function writeConfiguration(config) {
   fs.writeFileSync(frontendConfigPath, frontendConfig, 'utf8');
   console.log(`✅ Updated ${frontendConfigPath}.`);
 
+  // Check if chain ID needs manual configuration
+  const chainInfo = CHAIN_ID_TO_RPC[config.chainID];
+  if (!chainInfo && config.chainID !== CURVEGRID_PRIVATE_TESTNET_CHAIN_ID) {
+    console.warn(`⚠️  Chain ID ${config.chainID} is not automatically supported.`);
+    console.warn(`   Please add a custom chain configuration to frontend/app/providers.tsx`);
+    console.warn(`   Follow the template in providers.tsx for guidance.`);
+  }
+
 }
 
 async function setupPrivateDeployerKey(config) {


### PR DESCRIPTION
Prompt the user to update the chain configuration manually if it is not found by the chain ID during post-installation.